### PR TITLE
Table declaration+Clefs, Valeurs functions.

### DIFF
--- a/fralgo.vim
+++ b/fralgo.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: ALGO
 " Maintainer: Stéphane MEYER (Teegre)
-" Last change: 2024/05/08
+" Last change: 2024/05/11
 
 if exists("b:current_syntax")
   finish
@@ -33,21 +33,21 @@ syn match Assignment "←\|<-"
 
 syn keyword Import Importer
 syn keyword VarDeclaration Variable Variables Tableau Tableaux
-syn keyword Structure Structure FinStructure
+syn keyword Structure Structure FinStructure Table FinTable
 syn keyword VarType Booléen Caractère Chaîne Entier Numérique
 syn keyword Program Début Fin
 syn keyword Library Librairie Initialise
 syn keyword File Ajout Ecriture Lecture
 syn keyword Func Fonction Retourne FinFonction
 syn keyword Proc Procédure FinProcédure
-syn keyword StockFunc Aléa Car CodeCar Dormir Droite Ecrire EcrireErr EcrireFichier Extraire
-syn keyword StockFunc FDF Fermer Gauche Lire LireFichier Longueur NON Ouvrir Redim Taille
+syn keyword StockFunc Aléa Car Clefs CodeCar Dormir Droite Ecrire EcrireErr EcrireFichier Extraire
+syn keyword StockFunc FDF Fermer Gauche Lire LireFichier Longueur NON Ouvrir Redim Taille Valeurs
 syn keyword StockFunc TempsUnix Trouve
 syn keyword Loop TantQue FinTantQue Pour Suivant
 syn keyword Condition Si Alors SinonSi Sinon FinSi
 syn keyword Bool VRAI FAUX
 syn keyword Conjonction à en sur
-syn keyword Arguments _ARGS
+syn keyword Arguments _ARGS Clef Valeur
 syn region AlgoString start='"' skip=/\v\\./ end='"'
 syn region AlgoString start="'" skip=/\v\\./ end="'"
 
@@ -55,10 +55,6 @@ syn keyword AlgoTodo TODO FIXME NOTE NOTES contained
 syn match AlgoComment "#.*" contains=Todo
 
 syn match ID "\v[a-zA-Zàéè_(][a-zA-Z0-9-_:)]*" display contained
-
-" syn keyword powStatement def  nextgroup=powID skipwhite 
-" syn keyword powStatement set  nextgroup=powID skipwhite
-" syn keyword powStatement setg nextgroup=powID skipwhite
 
 syn match AlgoNumber "\<\d\+"
 syn match AlgoNumber "[-]\d\+"

--- a/fralgo/fralgolex.py
+++ b/fralgo/fralgolex.py
@@ -4,7 +4,7 @@
 # |    ___|      <______|       |       |    |  |   -   |
 # |___|   |___|__|      |___|___|_______|_______|_______|
 #
-# This file is part of FRALGO
+# This file is part of FR-ALGO
 # Copyright © 2024 Stéphane MEYER (Teegre)
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -41,6 +41,8 @@ reserved = {
   'Car':           'CHR',
   'Caractère':     'TYPE_CHAR',
   'Chaîne':        'TYPE_STRING',
+  'Clef':          'KEY',
+  'Clefs':         'KEYS',
   'CodeCar':       'ORD',
   'DP':            'DIVBY',
   'Dormir':        'SLEEP',
@@ -60,6 +62,7 @@ reserved = {
   'FinProcédure':  'ENDPROCEDURE',
   'FinSi':         'ENDIF',
   'FinStructure':  'ENDSTRUCT',
+  'FinTable':      'ENDTABLE',
   'FinTantQue':    'ENDWHILE',
   'Fonction':      'FUNCTION',
   'Gauche':        'LTRIM',
@@ -92,6 +95,8 @@ reserved = {
   'TantQue':       'WHILE',
   'TempsUnix':     'UNIXTIMESTAMP',
   'Trouve':        'FIND',
+  'Valeur':        'VALUE',
+  'Valeurs':       'VALUES',
   'Variable':      'VAR_DECL',
   'Variables':     'VARS_DECL',
   'en':            'TYPE_DECL',
@@ -140,7 +145,7 @@ t_ignore = ' \t'
 
 def t_STRING(t):
   r'\".*?\"|\'.*?\''
-  t.value = t.value[1:-1].encode('latin-1').decode('unicode-escape')
+  t.value = t.value[1:-1].encode('latin-1', 'ignore').decode('unicode-escape')
   return t
 
 def t_NOTHING(t):

--- a/fralgo/fralgoparse.py
+++ b/fralgo/fralgoparse.py
@@ -4,7 +4,7 @@
 # |    ___|      <______|       |       |    |  |   -   |
 # |___|   |___|__|      |___|___|_______|_______|_______|
 #
-# This file is part of FRALGO
+# This file is part of FR-ALGO
 # Copyright © 2024 Stéphane MEYER (Teegre)
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -30,9 +30,10 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
-from fralgo.lib.ast import Node, Declare, DeclareArray, DeclareStruct
+from fralgo.lib.ast import Node, Declare, DeclareArray, DeclareTable, DeclareStruct
 from fralgo.lib.ast import StructureGetItem, StructureSetItem
 from fralgo.lib.ast import ArrayGetItem, ArraySetItem, ArrayResize
+from fralgo.lib.ast import TableGetKeys, TableGetValues
 from fralgo.lib.ast import Assign, Variable, Print, PrintErr, Read, BinOp, Neg
 from fralgo.lib.ast import If, While, For, Len, Mid, Trim, Chr, Ord, Find
 from fralgo.lib.ast import ToFloat, ToInteger, ToString, Random, Sleep, SizeOf
@@ -94,6 +95,18 @@ def p_import_statement(p):
   '''
   p[0] = Node(Import(p[2], yacc()), p.lineno(1))
 
+def p_table_declaration(p):
+  '''
+  table_declaration : TYPE_TABLE ID NEWLINE table_fields ENDTABLE NEWLINE
+  '''
+  p[0] = Node(DeclareTable(p[2], p[4][0], p[4][1]), p.lineno(1))
+
+def p_table_fields(p):
+  '''
+  table_fields : KEY TYPE_DECL type NEWLINE VALUE TYPE_DECL type NEWLINE
+  '''
+  p[0] = [p[3], p[7]]
+
 def p_structure_declarations(p):
   '''
   struct_declarations : struct_declarations struct_declaration
@@ -145,6 +158,7 @@ def p_var_declaration(p):
                   | ARRAYS_DECL array_list TYPE_DECL type NEWLINE
                   | VAR_DECL ID TYPE_DECL type NEWLINE
                   | VARS_DECL var_list TYPE_DECL type NEWLINE
+                  | table_declaration
                   | struct_declarations
                   | function_declaration
                   | procedure_declaration
@@ -241,7 +255,6 @@ def p_type(p):
        | TYPE_INTEGER
        | TYPE_STRING
        | sized_char
-       | TYPE_TABLE
        | ID
   '''
   p[0] = p[1]
@@ -751,6 +764,18 @@ def p_expression_structure_get_item(p):
   expression : structure_get_item
   '''
   p[0] = p[1]
+
+def p_table_keys(p):
+  '''
+  expression : KEYS LPAREN expression RPAREN
+  '''
+  p[0] = TableGetKeys(p[3])
+
+def p_table_values(p):
+  '''
+  expression : VALUES LPAREN expression RPAREN
+  '''
+  p[0] = TableGetValues(p[3])
 
 def p_expression_len(p):
   '''

--- a/fralgo/fralgorepl.py
+++ b/fralgo/fralgorepl.py
@@ -44,10 +44,10 @@ user_path = os.path.expanduser('~')
 history_file = os.path.join(user_path, '.fralgohistory')
 
 class Interpreter:
-  start_hook = ('Fonction', 'Procédure', 'TantQue', 'Pour', 'Si', 'Sinon', 'SinonSi', 'Structure')
-  loop_hook = ('Fonction', 'Procédure', 'TantQue', 'Pour', 'Si', 'Structure')
+  start_hook = ('Fonction', 'Table', 'Procédure', 'TantQue', 'Pour', 'Si', 'Sinon', 'SinonSi', 'Structure')
+  loop_hook = ('Fonction', 'Table', 'Procédure', 'TantQue', 'Pour', 'Si', 'Structure')
   while_end_hook = 'Suivant'
-  end_hook = ('FinTantQue', 'FinSi', 'FinStructure', 'FinFonction', 'FinProcédure')
+  end_hook = ('FinTantQue', 'FinSi', 'FinTable', 'FinStructure', 'FinFonction', 'FinProcédure')
   def __init__(self):
     self.loop = False
     self.cancel = False

--- a/fralgo/lib/ast.py
+++ b/fralgo/lib/ast.py
@@ -4,7 +4,7 @@
 # |    ___|      <______|       |       |    |  |   -   |
 # |___|   |___|__|      |___|___|_______|_______|_______|
 #
-# This file is part of FRALGO
+# This file is part of FR-ALGO
 # Copyright © 2024 Stéphane MEYER (Teegre)
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -134,6 +134,16 @@ class DeclareSizedChar:
   def __repr__(self):
     return f'Variable {self.name}*{self.size}'
 
+class DeclareTable:
+  def __init__(self, name, key_type, value_type):
+    self.name = name
+    self.key_type = key_type
+    self.value_type = value_type
+  def eval(self):
+    sym.declare_table(self.name, self.key_type, self.value_type)
+  def __repr__(self):
+    return f'Table {self.name}'
+
 class DeclareStruct:
   __types = ('Booléen', 'Caractère', 'Chaîne', 'Entier', 'Numérique')
   def __init__(self, name, fields):
@@ -199,40 +209,14 @@ class SizeOf:
   def __repr__(self):
     return f'Taille({self.var})'
 
-# class DeclareTable:
-#   __types = ('Booléen', 'Caractère', 'Chaîne', 'Entier', 'Numérique')
-#   def __init__(self, key_type, value_type):
-#     self.key_type = key_type
-#     self.value_type = value_type
-#   def eval(self):
-
-class TableGetItem:
-  def __init__(self, var, key):
-    self.var = var
-    self.key = key
-  def eval(self):
-    var = self.var.eval()
-    return var.get_item(self.key)
-  def __repr__(self):
-    return f'{self.var}[{self.key}]'
-
-class TableSetItem:
-  def __init__(self, var, key, value):
-    self.var = var
-    self.key = key
-    self.value = value
-  def eval(self):
-    var = self.var.eval()
-    return var.set_value(self.key, self.value)
-  def __repr__(self):
-    return f'{self.var}[{self.key}] ← {self.value}'
-
 class TableGetKeys:
   def __init__(self, var):
     self.var = var
   def eval(self):
     var = self.var.eval()
-    return var.get_keys()
+    keys = Array(self.var.key_type, len(var.get_keys()) - 1)
+    keys.value = list(var.get_keys())
+    return keys
   def __repr__(self):
     return f'Clefs({self.var})'
 
@@ -241,7 +225,9 @@ class TableGetValues:
     self.var = var
   def eval(self):
     var = self.var.eval()
-    return var.get_values()
+    values =Array(self.var.value_type, len(var.get_values()) - 1)
+    values.value = list(var.get_values())
+    return values
   def __repr__(self):
     return f'Valeurs({self.var})'
 
@@ -454,6 +440,18 @@ class Variable:
   def data_type(self):
     var = sym.get_variable(self.name)
     return var.data_type
+  @property
+  def key_type(self):
+    if self.data_type == 'Table':
+      var = sym.get_variable(self.name)
+      return var.key_type
+    raise BadType(f'La variable {self.name} n\'est pas de type Table')
+  @property
+  def value_type(self):
+    if self.data_type == 'Table':
+      var = sym.get_variable(self.name)
+      return var.value_type
+    raise BadType(f'La variable {self.name} n\'est pas de type Table')
 
 class Reference(Variable):
   def __repr__(self):

--- a/fralgo/lib/datatypes.py
+++ b/fralgo/lib/datatypes.py
@@ -577,14 +577,19 @@ class StructureData(Base):
 
 class Table(Base):
   _type = 'Table'
-  def __init__(self, value=None):
+  def __init__(self, key_type, value_type, value=None):
+    self.key_type = key_type
+    self.value_type = value_type
     self.value = {} if value is None else {}
   def eval(self):
-    if len(self.value) > 0:
-      return self.value
-    raise VarUndefined('Valeur indéfinie')
+    return self
   def set_value(self, key, value):
-    self.value[key[0].eval()] = value.eval()
+    key = key[0]
+    if key.data_type != self.key_type:
+      raise BadType(f'Clef : Type {self.key_type} attendu')
+    if value.data_type != self.value_type:
+      raise BadType(f'Valeur : Type {self.value_type} attendu')
+    self.value[key.eval()] = value.eval()
   def get_item(self, key):
     value = self.value.get(key.eval())
     if value is not None:
@@ -594,6 +599,8 @@ class Table(Base):
     return self.value.keys()
   def get_values(self):
     return self.value.values()
+  def __len__(self):
+    return len(self.value)
   def __repr__(self):
     return f'({(", ".join(str(k) + ": " + str(v) for k, v in self.value.items()))})'
 

--- a/fralgo/lib/symbols.py
+++ b/fralgo/lib/symbols.py
@@ -26,7 +26,7 @@
 # OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import fralgo.lib.exceptions as ex
-from fralgo.lib.datatypes import Array, Char, StructureData
+from fralgo.lib.datatypes import Array, Char, StructureData, Table
 
 class Symbols:
   __func         = 'functions'
@@ -117,6 +117,14 @@ class Symbols:
     array.set_get_structure(self.get_structure)
     array.value = array.new_array(*array.sizes)
     variables[name] = array
+  def declare_table(self, name, key_type, value_type):
+    if self.is_local():
+      variables = self.get_local_table()
+    else:
+      variables = self.table[self.__vars]
+    if variables.get(name, None) is not None:
+      raise ex.VarRedeclared(f'Redéclaration de la variable {name}')
+    variables[name] = Table(key_type, value_type)
   def declare_sized_char(self, name, size):
     if self.is_local():
       variables = self.get_local_table()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -19,6 +19,32 @@ def reset_parser():
 
 class Test(unittest.TestCase):
 
+  def test_table(self):
+    prog='''Table t
+      Clef en Entier
+      Valeur en Entier
+    FinTable
+    Variables clef, valeur en Entier
+    Variables test1, test2 en Booléen
+    Début
+      Ecrire "17. Test Table"
+      clef <- Entier(Aléa() * 255 + 1)
+      valeur <- Entier(Aléa() * 255 + 1)
+      t[clef] <- valeur
+      test1 <- t[clef] = valeur
+      test2 <- t[0] = ?
+      Ecrire test1, test2
+    Fin'''
+
+    reset_parser()
+    statements = parser.parse(prog)
+    statements.eval()
+    t1 = sym.get_variable('test1')
+    t2 = sym.get_variable('test2')
+    self.assertEqual(t1.eval(), True, 'test1 should be VRAI')
+    self.assertEqual(t2.eval(), True, 'test2 should be VRAI')
+    print()
+
   def test_procedure_split(self):
     prog = '''Procédure scinder(chaine, separateur, &elements[] en Chaîne)
      Variable sous_chaine en Chaîne


### PR DESCRIPTION
Les clefs et les valeurs d'une `Table` doivent dorénavant être typées :
```
Table t
  Clef en Chaîne
  Valeur en Entier
FinTable

t["A"] <- 65
t["B"] <- 66
t["A"] = 65
# VRAI
```
Il est possible d'obtenir la longueur d'une `Table` avec la fonction `Longueur` :
```
Longueur(t)
# 2
```

Les fonctions **Clefs** et **Valeurs** retournent respectivement les clefs et les valeurs d"une `Table` sous forme d'un `Tableau` :
```
Clefs(t)
# ["A", "B"]
Valeurs(t)
# [65, 66]
```